### PR TITLE
Deploy ID flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Workaround : Archive manually all your unecessary deployments. [If you want to f
 
 Description of the deployment.
 
+### `deployId`
+
+Deploy ID that will be updated with this push.
+
 ## Example usage
 
 ### Case to push
@@ -104,6 +108,22 @@ Description of the deployment.
     rootDir: 'src'
     command: 'push'
 ```
+
+### Case to update a specific deploy
+
+```yaml
+- uses: daikikatsuragawa/clasp-action@v1
+  with:
+    accessToken: ${{ secrets.ACCESS_TOKEN }}
+    idToken: ${{ secrets.ID_TOKEN }}
+    refreshToken: ${{ secrets.REFRESH_TOKEN }}
+    clientId: ${{ secrets.CLIENT_ID }}
+    clientSecret: ${{ secrets.CLIENT_SECRET }}
+    scriptId: ${{ secrets.SCRIPT_ID }}
+    command: 'deploy'
+    deployId: ${{ secrets.DEPLOY_ID }}
+```
+
 
 ## License summary
 

--- a/action.yml
+++ b/action.yml
@@ -31,12 +31,15 @@ inputs:
   description:
     description: 'Description of the deployment'
     required: false
+  deployId:
+    description: 'Deploy ID that will be updated'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.accessToken }}
-    - ${{ inputs.idToken }} 
+    - ${{ inputs.idToken }}
     - ${{ inputs.refreshToken }}
     - ${{ inputs.clientId }}
     - ${{ inputs.clientSecret }}
@@ -44,3 +47,4 @@ runs:
     - ${{ inputs.rootDir }}
     - ${{ inputs.command }}
     - ${{ inputs.description }}
+    - ${{ inputs.deployId }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,13 +41,23 @@ echo $CLASP > .clasp.json
 
 if [ "$8" = "push" ]; then
   clasp push -f
-elif  [ "$8" = "deploy" ]; then
+elif [ "$8" = "deploy" ]; then
   if [ -n "$9" ]; then
     clasp push -f
-    clasp deploy --description "$9"
-  else 
+
+    if [ -n "${10}" ]; then
+      clasp deploy --description $9 -i ${10}
+    else
+      clasp deploy --description $9
+    fi
+  else
     clasp push -f
-    clasp deploy
+
+    if [ -n "${10}" ]; then
+      clasp deploy -i ${10}
+    else
+      clasp deploy
+    fi
   fi
 else
   echo "command is invalid."


### PR DESCRIPTION
Hi, I have added a flag to update an specific deploy ID, in this way you can update the actual URL of the script with this action. 

This solves as well the limitation of 20 deploys, as you will be updating an specific one.

If you see anything strange, just comment it and I'll change it.