### PR TITLE
Fix argument parsing for clasp deployment description and ID

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,15 +46,15 @@ elif [ "$8" = "deploy" ]; then
     clasp push -f
 
     if [ -n "${10}" ]; then
-      clasp deploy --description $9 -i ${10}
+      clasp deploy --description "$9" -i "${10}"
     else
-      clasp deploy --description $9
+      clasp deploy --description "$9"
     fi
   else
     clasp push -f
 
     if [ -n "${10}" ]; then
-      clasp deploy -i ${10}
+      clasp deploy -i "${10}"
     else
       clasp deploy
     fi


### PR DESCRIPTION
Hi, I've addresses an issue in the shell script where the deployment description argument for clasp could be incorrectly parsed when it included spaces or special characters.

Specifically, if we wanted to embed the commit message into the description, such as description: `${{ github.event.head_commit.message }}`, and if the commit message included spaces or other special characters, they would cause the 9th argument ($9), which is supposed to represent the description, to be cut off at the first occurrence of a space.

To solve this issue, I've modified the script to surround arguments with double quotes, ensuring that the full description is correctly parsed even when it includes spaces or special characters.