### PR TITLE
feat(action): pin dependencies, secure inputs, and do not completely overwrite existing config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:latest
+FROM node:20-alpine
+
+RUN apk add --no-cache jq
+
+RUN npm install -g @google/clasp@2.4.2
 
 COPY entrypoint.sh /entrypoint.sh
-
-RUN apk add --update npm
-
-RUN npm install -g @google/clasp
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -37,14 +37,3 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.accessToken }}
-    - ${{ inputs.idToken }}
-    - ${{ inputs.refreshToken }}
-    - ${{ inputs.clientId }}
-    - ${{ inputs.clientSecret }}
-    - ${{ inputs.scriptId }}
-    - ${{ inputs.rootDir }}
-    - ${{ inputs.command }}
-    - ${{ inputs.description }}
-    - ${{ inputs.deployId }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,67 +1,71 @@
-#!/bin/sh -l
+#!/bin/sh
+set -e
 
-CLASPRC=$(cat <<-END
-    {
-        "token": {
-            "access_token": "$1",
-            "refresh_token": "$3",
-            "scope": "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/service.management https://www.googleapis.com/auth/script.deployments https://www.googleapis.com/auth/logging.read https://www.googleapis.com/auth/script.webapp.deploy https://www.googleapis.com/auth/userinfo.profile openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/script.projects https://www.googleapis.com/auth/drive.metadata.readonly",
-            "token_type": "Bearer",
-            "id_token": "$2"
-        },
-        "oauth2ClientSettings": {
-            "clientId": "$4",
-            "clientSecret": "$5",
-            "redirectUri": "http://localhost"
-        },
-        "isLocalCreds": false
-    }
-END
+# Construct ~/.clasprc.json using automatically populated input environment variables
+CLASPRC=$(cat <<-EOF
+{
+    "token": {
+        "access_token": "$INPUT_ACCESSTOKEN",
+        "refresh_token": "$INPUT_REFRESHTOKEN",
+        "scope": "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/service.management https://www.googleapis.com/auth/script.deployments https://www.googleapis.com/auth/logging.read https://www.googleapis.com/auth/script.webapp.deploy https://www.googleapis.com/auth/userinfo.profile openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/script.projects https://www.googleapis.com/auth/drive.metadata.readonly",
+        "token_type": "Bearer",
+        "id_token": "$INPUT_IDTOKEN"
+    },
+    "oauth2ClientSettings": {
+        "clientId": "$INPUT_CLIENTID",
+        "clientSecret": "$INPUT_CLIENTSECRET",
+        "redirectUri": "http://localhost"
+    },
+    "isLocalCreds": false
+}
+EOF
 )
 
-echo $CLASPRC > ~/.clasprc.json
+# Safely write the clasprc config with quotes
+echo "$CLASPRC" > ~/.clasprc.json
 
-CLASP=$(cat <<-END
-    {
-        "scriptId": "$6"
-    }
-END
-)
-
-if [ -n "$7" ]; then
-  if [ -e "$7" ]; then
-    cd "$7"
+# If rootDir is specified, validate and cd into it
+if [ -n "$INPUT_ROOTDIR" ]; then
+  if [ -d "$INPUT_ROOTDIR" ]; then
+    cd "$INPUT_ROOTDIR"
   else
-    echo "rootDir is invalid."
+    echo "rootDir '$INPUT_ROOTDIR' is invalid or does not exist."
     exit 1
   fi
 fi
 
-echo $CLASP > .clasp.json
+# Merge scriptId into .clasp.json instead of overwriting destructively
+if [ -f ".clasp.json" ]; then
+  echo "Existing .clasp.json found. Merging scriptId..."
+  # Use jq to update or insert scriptId, preserving other settings
+  jq --arg scriptId "$INPUT_SCRIPTID" '.scriptId = $scriptId' .clasp.json > temp.json && mv temp.json .clasp.json
+else
+  echo "Creating new .clasp.json..."
+  cat <<-EOF > .clasp.json
+  {
+      "scriptId": "$INPUT_SCRIPTID"
+  }
+EOF
+fi
 
-if [ "$8" = "push" ]; then
+# Execute command
+if [ "$INPUT_COMMAND" = "push" ]; then
   clasp push -f
-elif [ "$8" = "pull" ]; then
+elif [ "$INPUT_COMMAND" = "pull" ]; then
   clasp pull
-elif [ "$8" = "deploy" ]; then
-  if [ -n "$9" ]; then
-    clasp push -f
+elif [ "$INPUT_COMMAND" = "deploy" ]; then
+  clasp push -f
 
-    if [ -n "${10}" ]; then
-      clasp deploy --description "$9" -i "${10}"
-    else
-      clasp deploy --description "$9"
-    fi
+  if [ -n "$INPUT_DESCRIPTION" ] && [ -n "$INPUT_DEPLOYID" ]; then
+    clasp deploy --description "$INPUT_DESCRIPTION" -i "$INPUT_DEPLOYID"
+  elif [ -n "$INPUT_DESCRIPTION" ]; then
+    clasp deploy --description "$INPUT_DESCRIPTION"
+  elif [ -n "$INPUT_DEPLOYID" ]; then
+    clasp deploy -i "$INPUT_DEPLOYID"
   else
-    clasp push -f
-
-    if [ -n "${10}" ]; then
-      clasp deploy -i "${10}"
-    else
-      clasp deploy
-    fi
+    clasp deploy
   fi
 else
-  echo "command is invalid."
+  echo "command '$INPUT_COMMAND' is invalid."
   exit 1
 fi


### PR DESCRIPTION
- Dockerfile: Pin base image to node:20-alpine and clasp dependency to v2.4.2 to prevent unexpected runtime failures if dependent packages push a breaking change.
- Dockerfile: Install jq to support JSON configuration merging.
- action.yml: Remove command-line args to read secrets directly from environment variables, preventing credential leakage via host process tables.
- entrypoint.sh: Enable `set -e` to ensure execution fails fast and propagates errors to the runner.
- entrypoint.sh: Merge clasp scriptId non-destructively using jq to preserve custom configurations (e.g., rootDir, projectId).